### PR TITLE
Fix tests with packages

### DIFF
--- a/src/main/kotlin/com/maedjyukghoti/tictactoe/logic/Datatypes.kt
+++ b/src/main/kotlin/com/maedjyukghoti/tictactoe/logic/Datatypes.kt
@@ -183,15 +183,12 @@ data class Board(val moves: List<MoveRequest>, val bounds: Int) {
 data class GameState(val board: Board, val currentPlayerInfo: PlayerInfo, val winner: PlayerInfo)
 
 /** Check the [Board] for a winning player. Return [PlayerInfo.None] if no winner is found. **/
-fun checkForWinner(board: Board): PlayerInfo {
-    if (board.moves.count() < ((board.bounds * 2) - 1)) return PlayerInfo.None
-    // Group moves based on who played them
-    return board.moves.groupBy(MoveRequest::playerInfo, MoveRequest::coordinates)
+fun checkForWinner(board: Board): PlayerInfo =
+    board.moves.groupBy(MoveRequest::playerInfo, MoveRequest::coordinates)    // Group moves based on who played them
         .asSequence()
         .filter { (_, moveSet) -> moveSet.count() >= board.bounds }
         .firstOrNull { (_, moveSet) -> checkForConsecutiveCoordinates(moveSet, board.bounds) }
         ?.component1() ?: PlayerInfo.None
-}
 
 fun checkForConsecutiveCoordinates(moveSet: List<Coordinates>, bounds: Int): Boolean {
     // Not enough moves to win

--- a/src/test/kotlin/BoardTest.kt
+++ b/src/test/kotlin/BoardTest.kt
@@ -1,3 +1,4 @@
+import com.maedjyukghoti.tictactoe.logic.Board
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/src/test/kotlin/CheckForWinner.kt
+++ b/src/test/kotlin/CheckForWinner.kt
@@ -1,3 +1,4 @@
+import com.maedjyukghoti.tictactoe.logic.Board
 import com.maedjyukghoti.tictactoe.logic.Coordinates
 import com.maedjyukghoti.tictactoe.logic.MoveRequest
 import com.maedjyukghoti.tictactoe.logic.PlayerInfo

--- a/src/test/kotlin/CheckForWinnerStaticTest.kt
+++ b/src/test/kotlin/CheckForWinnerStaticTest.kt
@@ -1,7 +1,4 @@
-import com.maedjyukghoti.tictactoe.logic.Coordinates
-import com.maedjyukghoti.tictactoe.logic.MoveRequest
-import com.maedjyukghoti.tictactoe.logic.PlayerInfo
-import com.maedjyukghoti.tictactoe.logic.checkForWinner
+import com.maedjyukghoti.tictactoe.logic.*
 import org.junit.Test
 import kotlin.test.assertEquals
 

--- a/src/test/kotlin/ComputerPlayerTest.kt
+++ b/src/test/kotlin/ComputerPlayerTest.kt
@@ -1,3 +1,4 @@
+import com.maedjyukghoti.tictactoe.logic.Board
 import com.maedjyukghoti.tictactoe.logic.Coordinates
 import com.maedjyukghoti.tictactoe.logic.MoveRequest
 import com.maedjyukghoti.tictactoe.logic.PlayerInfo

--- a/src/test/kotlin/MakeMoveTest.kt
+++ b/src/test/kotlin/MakeMoveTest.kt
@@ -1,6 +1,7 @@
 import com.maedjyukghoti.tictactoe.logic.Coordinates
 import com.maedjyukghoti.tictactoe.logic.MoveRequest
 import com.maedjyukghoti.tictactoe.logic.PlayerInfo
+import com.maedjyukghoti.tictactoe.logic.makeMove
 import org.junit.Test
 import kotlin.test.assertTrue
 

--- a/src/test/kotlin/Undo.kt
+++ b/src/test/kotlin/Undo.kt
@@ -1,3 +1,4 @@
+import com.maedjyukghoti.tictactoe.logic.Board
 import com.maedjyukghoti.tictactoe.logic.Coordinates
 import com.maedjyukghoti.tictactoe.logic.MoveRequest
 import com.maedjyukghoti.tictactoe.logic.PlayerInfo

--- a/src/test/kotlin/ValidateTest.kt
+++ b/src/test/kotlin/ValidateTest.kt
@@ -1,6 +1,4 @@
-import com.maedjyukghoti.tictactoe.logic.Coordinates
-import com.maedjyukghoti.tictactoe.logic.MoveRequest
-import com.maedjyukghoti.tictactoe.logic.PlayerInfo
+import com.maedjyukghoti.tictactoe.logic.*
 import org.junit.Test
 import kotlin.test.assertNotNull
 

--- a/src/test/kotlin/com/maedjyukghoti/tictactoe/logic/players/MinimaxTest.kt
+++ b/src/test/kotlin/com/maedjyukghoti/tictactoe/logic/players/MinimaxTest.kt
@@ -1,6 +1,6 @@
 package com.maedjyukghoti.tictactoe.logic.players
 
-import Board
+import com.maedjyukghoti.tictactoe.logic.Board
 import com.maedjyukghoti.tictactoe.logic.Coordinates
 import com.maedjyukghoti.tictactoe.logic.MoveRequest
 import com.maedjyukghoti.tictactoe.logic.PlayerInfo

--- a/src/test/kotlin/helpers.kt
+++ b/src/test/kotlin/helpers.kt
@@ -1,3 +1,5 @@
+import com.maedjyukghoti.tictactoe.logic.Board
+
 fun getEmptyBoard(size: Int): Board {
     return Board(emptyList(), size)
 }


### PR DESCRIPTION
Packages were missing after moving things around.

Tests were failing around `checkForWinner`. Issue was that it was always returning false when the tests didn't have enough moves to have a win in a _legal_ game. This issue has been around since switching from `board.checkForWinner` to the new/static `checkForWinner`